### PR TITLE
Add customizable dim transition times.

### DIFF
--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -29,6 +29,7 @@
   <string id="510">Changes will be active after restarting XBMC</string>
   <string id="501">Dimmed brightness</string>
   <string id="502">Undimmed brightness</string>
+  <string id="507">Dim/Undim transition time</string>
   <string id="506">Override Hue colors</string>
   <string id="503">Dimmed Hue color</string>
   <string id="504">Undimmed Hue color</string>

--- a/resources/lib/settings.py
+++ b/resources/lib/settings.py
@@ -23,6 +23,7 @@ class settings():
     self.dimmed_bri            = int(int(__addon__.getSetting("dimmed_bri").split(".")[0])*254/100)
     self.override_undim_bri    = __addon__.getSetting("override_undim_bri") == "true"
     self.undim_bri             = int(int(__addon__.getSetting("undim_bri").split(".")[0])*254/100)
+    self.dim_time              = int(float(__addon__.getSetting("dim_time"))*10)
     self.override_hue          = __addon__.getSetting("override_hue") == "true"
     self.dimmed_hue            = int(__addon__.getSetting("dimmed_hue").split(".")[0])
     self.undim_hue             = int(__addon__.getSetting("undim_hue").split(".")[0])

--- a/resources/lib/tools.py
+++ b/resources/lib/tools.py
@@ -87,6 +87,7 @@ class Light:
     self.bridge_ip    = settings.bridge_ip
     self.bridge_user  = settings.bridge_user
     self.light        = light_id
+    self.dim_time     = settings.dim_time
     self.override_hue = settings.override_hue
     self.dimmed_bri   = settings.dimmed_bri
     self.dimmed_hue   = settings.dimmed_hue
@@ -156,15 +157,17 @@ class Light:
     self.valLast = bri
 
   def flash_light(self):
-    self.dim_light()
-    self.brighter_light()
+    self.dim_light(dim_time=4)
+    self.brighter_light(dim_time=4)
 
-  def dim_light(self):
+  def dim_light(self, dim_time=None):
+    if dim_time == None:
+      dim_time = self.dim_time
     if self.override_hue:
-      dimmed = '{"on":true,"bri":%s,"hue":%s,"transitiontime":4}' % (self.dimmed_bri, self.dimmed_hue)
+      dimmed = '{"on":true,"bri":%s,"hue":%s,"transitiontime":%d}' % (self.dimmed_bri, self.dimmed_hue, dim_time)
       self.hueLast = self.dimmed_hue
     else:
-      dimmed = '{"on":true,"bri":%s,"transitiontime":4}' % self.dimmed_bri
+      dimmed = '{"on":true,"bri":%s,"transitiontime":%d}' % (self.dimmed_bri, dim_time)
     self.valLast = self.dimmed_bri
     self.set_light(dimmed)
     if self.dimmed_bri == 0:
@@ -172,8 +175,10 @@ class Light:
       self.set_light(off)
       self.valLast = 0
 
-  def brighter_light(self):
-    data = '{"on":true,"transitiontime":4'
+  def brighter_light(self, dim_time=None):
+    if dim_time == None:
+		dim_time = self.dim_time
+    data = '{"on":true,"transitiontime":%d' % (dim_time)
     if self.override_hue:
       data += ',"hue":%s' % self.undim_hue
       self.hueLast = self.undim_hue

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -20,6 +20,7 @@
     <category label="500">
         <setting type="lsep" label="510" />
         <setting id="dimmed_bri" label="501" type="slider" default="0" range="0,5,100" option="int" />
+        <setting id="dim_time" label="507" type="slider" default="0.5" range="0,0.5,10" option="float" />
         <setting id="override_undim_bri" type="bool" label="511" default="false" />
         <setting id="undim_bri" label="502" type="slider" visible="eq(-1,true)" default="80" range="0,5,100" option="int" />
         <setting id="override_hue" type="bool" label="506" default="false" />


### PR DESCRIPTION
The default 400ms transition time from bright to black during dimming/undimming was a bit jarring, so I made that customizable with a slider.

The Hue API allows for 100ms increments, but I gave the slider a 500ms stepping under the assumption that some people might want long (~10s) transitions. That can easily be changed in settings.xml if it turns out users want more fine-grained control within a smaller spectrum.
